### PR TITLE
Fix FE logins in TYPO3 v11 events

### DIFF
--- a/Classes/EventListener/LoadAclsFromHell.php
+++ b/Classes/EventListener/LoadAclsFromHell.php
@@ -23,6 +23,11 @@ class LoadAclsFromHell
      */
     public function __invoke(AfterGroupsResolvedEvent $event): void
     {
+        if ($event->getSourceDatabaseTable() !== 'be_groups') {
+            // we are only interested in backend users
+            return;
+        }
+
         $yamlLoader = GeneralUtility::makeInstance(YamlFileLoader::class);
 
         $groups = $event->getGroups();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,0 @@
-<?php
-
-defined('TYPO3') || die('Access denied.');
-
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauthgroup.php']['fetchGroups_postProcessing']['loadAclsFromHell'] = \Cron\AclsFromHell\Hooks\BackendUserAuthentication::class . '->loadAclsFromHell';


### PR DESCRIPTION
Fix logins in the frontend: ignore event if the login is not a backend user.